### PR TITLE
ci(node): drop node 8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Node 8 EOL: 2019-12-31

https://nodejs.org/en/about/releases/