### PR TITLE
ci: fix publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements",
-  "version": "4.0.1-beta.0",
+  "version": "4.0.1-beta.1",
   "license": "MIT",
   "author": "chimurai",
   "homepage": "https://github.com/chimurai/requirements",


### PR DESCRIPTION
`Error: fatal: could not read Username for 'https://github.com': terminal prompts disabled`

<img width="959" height="475" alt="image" src="https://github.com/user-attachments/assets/15778263-746a-4902-938d-1a48c3bfe52a" />

https://github.com/chimurai/requirements/actions/runs/26333421144/job/77523130548

See:
https://github.com/orgs/community/discussions/183817#discussioncomment-17031069